### PR TITLE
poplar_recovery_builder.sh: Rename recovery_files to image_files

### DIFF
--- a/poplar_recovery_builder.sh
+++ b/poplar_recovery_builder.sh
@@ -42,7 +42,7 @@ ANDROID_USER_DATA_IMAGE=userdata.img
 MOUNT=mount		# mount point for disk image; also output directory
 
 # Directory in which copies of output files are created
-RECOVERY=recovery_files
+RECOVERY=image_files
 
 # This is the ultimate output file
 USB_SIZE=4000000	# A little under 2 GB in sectors


### PR DESCRIPTION
Now that we've a normal and recovery build, and using tftp for normal
flashing and usb drive for recovery, it's confusing to name the image
folder `recovery_files`, so rename it to `image_files`.

Signed-off-by: Victor Chong <victor.chong@linaro.org>