### PR TITLE
poplar_recovery_builder.sh: tftp fixes

### DIFF
--- a/poplar_recovery_builder.sh
+++ b/poplar_recovery_builder.sh
@@ -18,7 +18,7 @@ EMMC_SIZE=14942208	# 7296 MB in sectors (not hex)
 CHUNK_SIZE=524288	# Partition image chuck size in sectors (not hex)
 
 IN_ADDR=0x08000000	# Buffer address for compressed data in from USB (hex)
-OUT_ADDR=0x10000000	# Buffer address for uncompressed data for MMC (hex)
+OUT_ADDR=0x18000000	# Buffer address for uncompressed data for MMC (hex)
 SUB_ADDR=0x07800000	# Buffer address for sub-installer scripts
 
 EMMC_DEV=/dev/mmcblk0	# Linux path to main eMMC device on target
@@ -118,7 +118,7 @@ function parseargs() {
 	PARTS=$1
 	shift
 
-	LOAD_COMMAND=tftp
+	LOAD_COMMAND=tftpboot
 	INPUT_FILES=""
 
 	while [ $# -gt 0 ]; do


### PR DESCRIPTION
1. tftp command is renamed to tftpboot in the U-boot
2. Extend address range to be able to download partition image gzipped archives,
that are more than 128MB in size.

For example, if the latest Linaro(linaro-stretch-developer-20180416-89.tar.gz)
rootfs is used, partition32-of-8.gz created by the poplar_recovery_builder.sh
script is 132 MB, so basically it overlaps the range, that is used for
unziped data. Basically, after executing these commands:

=> tftpboot 0x08000000 recovery_files/partition3.2-of-8.gz
=> unzip 0x08000000 0x10000000 0x10000000
=> mmc write 0x10000000 0x000c2000 0x00080000

```
ETH1: PHY(phyaddr=3, rgmii) link UP: DUPLEX=FULL : SPEED=100M
Using gmac1 device
TFTP from server 10.103.106.70; our IP address is 10.103.106.64
Filename 'recovery_files/partition3.2-of-8.gz'.
Load address: 0x8000000
Loading: #################################################################

done
Bytes transferred = 138279169 (83df901 hex)
Error: inflate() returned -3
```

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`