### PR TITLE
poplar_recovery_builder.sh: call sync before umount to avoid EBUSY

### DIFF
--- a/poplar_recovery_builder.sh
+++ b/poplar_recovery_builder.sh
@@ -469,6 +469,7 @@ function partition_mount() {
 }
 
 function partition_unmount() {
+	sync
 	sudo umount ${MOUNT} || nope "unable to unmount partition"
 	unset MOUNTED
 }


### PR DESCRIPTION
After piped sudo tar/dd commands finish on the shell side, the kernel may still have pending writes in flight for the loop-mounted image. This leaves the mount point "busy" and causes umount to fail with "target is busy". Calling sync first flushes all pending I/O so the filesystem is fully idle before the unmount attempt.